### PR TITLE
update version of pretrain-cp-model to v0.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 RUN pip install --no-cache-dir -r requirements.txt
-RUN wget https://opni-public.s3.us-east-2.amazonaws.com/pretrain-models/control-plane-model.zip && unzip control-plane-model.zip
+RUN wget https://opni-public.s3.us-east-2.amazonaws.com/pretrain-models/control-plane-model-v0.1.2.zip && unzip control-plane-model-v0.1.2.zip
 
 CMD [ "python", "start-nulog-inference.py" ]

--- a/models/nulog/train_with_rawdata.py
+++ b/models/nulog/train_with_rawdata.py
@@ -16,7 +16,7 @@ def load_text():
         for idx, line in enumerate(fin):
             try:
                 log = json.loads(line)
-                log = log["log"].rstrip().lower()
+                log = log["log"]
                 log = masker.mask(log)
                 texts.append(log)
             except Exception as e:


### PR DESCRIPTION
the new model has been upload to `s3://opni-public/pretrain-models/control-plane-model-v0.1.2.zip`. 
training data: `s3://opni-public/pretrain-model-data/k8s-CP-input/mix-raw.log`

in this repo, I basically change the file in Dockerfile to the new model. 
Also deleted one line of python code which is not needed anymore.