### PR TITLE
nulog inference gpu service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,119 @@
+.vscode
+amun/__pycache__/
+*.pyc
+test/
+.DS_Store
+.idea/
+
+#project
+.venv/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+src/.coverage
+.coverage.*
+.cache
+src/.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+src/.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# vscode
+.vscode/
+
+# PyCharm
+.idea/
+
+*.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,5 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 RUN pip install --no-cache-dir -r requirements.txt
-RUN wget https://opni-public.s3.us-east-2.amazonaws.com/pretrain-models/control-plane-model-v0.1.2.zip && unzip control-plane-model-v0.1.2.zip
 
 CMD [ "python", "start-nulog-inference.py" ]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+IMAGE_NAME=tybalex/opni-inference:dev-gpu
+docker build . -t $IMAGE_NAME -f ./Dockerfile
+
+docker push $IMAGE_NAME

--- a/models/nulog/NuLogParser.py
+++ b/models/nulog/NuLogParser.py
@@ -134,7 +134,7 @@ class LogParser:
         )
         ## train if no model
         model.train()
-        logging.info("#######Training Model within {self.nr_epochs} epochs...######")
+        logging.info(f"#######Training Model within {self.nr_epochs} epochs...######")
         for epoch in range(self.nr_epochs):
             logging.info(f"Epoch: {epoch}")
             self.run_epoch(

--- a/nulog-inference-service/NulogServer.py
+++ b/nulog-inference-service/NulogServer.py
@@ -83,4 +83,7 @@ class NulogServer:
             else:
                 pred = (self.parser.predict(tokens))[0]
                 output.append(pred)
-        return output
+        result_dict = {}
+        for l, p in zip(logs, output):
+            result_dict[l] = p
+        return result_dict

--- a/nulog-inference-service/NulogServer.py
+++ b/nulog-inference-service/NulogServer.py
@@ -9,6 +9,11 @@ import inference as nuloginf
 from botocore.config import Config
 from NuLogParser import using_GPU
 
+LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
+logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__file__)
+logger.setLevel(LOGGING_LEVEL)
+
 MINIO_ACCESS_KEY = os.environ["MINIO_ACCESS_KEY"]
 MINIO_SECRET_KEY = os.environ["MINIO_SECRET_KEY"]
 MINIO_ENDPOINT = os.environ["MINIO_ENDPOINT"]
@@ -49,29 +54,29 @@ class NulogServer:
                     bucket_name, bucket_files[k], f"output/{bucket_files[k]}"
                 )
             except Exception as e:
-                logging.error(
+                logger.error(
                     "Cannot currently obtain necessary model files. Exiting function"
                 )
                 return
 
     def load(self, save_path="output/"):
         if using_GPU:
-            logging.debug("inferencing with GPU.")
+            logger.debug("inferencing with GPU.")
         else:
-            logging.debug("inferencing without GPU.")
+            logger.debug("inferencing without GPU.")
         try:
             self.parser = nuloginf.init_model(save_path=save_path)
             self.is_ready = True
-            logging.info("Nulog model gets loaded.")
+            logger.info("Nulog model gets loaded.")
         except Exception as e:
-            logging.error(f"No Nulog model currently {e}")
+            logger.error(f"No Nulog model currently {e}")
 
     def predict(self, logs: List[str]):
         """
         logs: masked logs
         """
         if not self.is_ready:
-            logging.warning("Warning: NuLog model is not ready yet!")
+            logger.warning("Warning: NuLog model is not ready yet!")
             return None
 
         # output = nuloginf.predict(self.parser, logs)

--- a/nulog-inference-service/NulogTrain.py
+++ b/nulog-inference-service/NulogTrain.py
@@ -30,7 +30,7 @@ def train_nulog_model(minio_client, windows_folder_path):
     parser.train(tokenized, nr_epochs=nr_epochs, num_samples=num_samples)
     all_files = os.listdir("output/")
     if "nulog_model_latest.pt" in all_files and "vocab.txt" in all_files:
-        logging.info("Completed training model")
+        logging.debug("Completed training model")
         minio_client.meta.client.upload_file(
             "output/nulog_model_latest.pt", "nulog-models", "nulog_model_latest.pt"
         )
@@ -39,7 +39,7 @@ def train_nulog_model(minio_client, windows_folder_path):
         )
         logging.info("Nulog model and vocab have been uploaded to Minio.")
     else:
-        logging.info("Nulog model was not able to be trained and saved successfully.")
+        logging.error("Nulog model was not able to be trained and saved successfully.")
         return False
     return True
 
@@ -56,18 +56,17 @@ def minio_setup_and_download_data(minio_client):
         logging.error(
             f"Could not connect to minio with endpoint_url={MINIO_ENDPOINT} aws_access_key_id={MINIO_ACCESS_KEY} aws_secret_access_key={MINIO_SECRET_KEY} "
         )
-        logging.info("Job failed")
         return False
 
     try:
         minio_client.meta.client.head_bucket(Bucket="nulog-models")
-        logging.info("nulog-models bucket exists")
+        logging.debug("nulog-models bucket exists")
     except botocore.exceptions.ClientError as e:
         # If a client error is thrown, then check that it was a 404 error.
         # If it was a 404 error, then the bucket does not exist.
         error_code = e.response["Error"]["Code"]
         if error_code == "404":
-            logging.info("nulog-models bucket does not exist so creating it now")
+            logging.warning("nulog-models bucket does not exist so creating it now")
             minio_client.create_bucket(Bucket="nulog-models")
     return True
 
@@ -144,4 +143,4 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        logging.info(f"Nulog training failed. Exception {e}")
+        logging.error(f"Nulog training failed. Exception {e}")

--- a/nulog-inference-service/NulogTrain.py
+++ b/nulog-inference-service/NulogTrain.py
@@ -1,0 +1,147 @@
+# Standard Library
+import asyncio
+import json
+import logging
+import os
+import shutil
+
+# Third Party
+import boto3
+import botocore
+from botocore.client import Config
+from botocore.exceptions import EndpointConnectionError
+from NuLogParser import LogParser
+from opni_nats import NatsWrapper
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(message)s")
+
+MINIO_ENDPOINT = os.environ["MINIO_ENDPOINT"]
+MINIO_ACCESS_KEY = os.environ["MINIO_ACCESS_KEY"]
+MINIO_SECRET_KEY = os.environ["MINIO_SECRET_KEY"]
+
+
+def train_nulog_model(minio_client, windows_folder_path):
+    nr_epochs = 3
+    num_samples = 0
+    parser = LogParser()
+    texts = parser.load_data(windows_folder_path)
+    tokenized = parser.tokenize_data(texts, isTrain=True)
+    parser.tokenizer.save_vocab()
+    parser.train(tokenized, nr_epochs=nr_epochs, num_samples=num_samples)
+    all_files = os.listdir("output/")
+    if "nulog_model_latest.pt" in all_files and "vocab.txt" in all_files:
+        logging.info("Completed training model")
+        minio_client.meta.client.upload_file(
+            "output/nulog_model_latest.pt", "nulog-models", "nulog_model_latest.pt"
+        )
+        minio_client.meta.client.upload_file(
+            "output/vocab.txt", "nulog-models", "vocab.txt"
+        )
+        logging.info("Nulog model and vocab have been uploaded to Minio.")
+    else:
+        logging.info("Nulog model was not able to be trained and saved successfully.")
+        return False
+    return True
+
+
+def minio_setup_and_download_data(minio_client):
+    try:
+        minio_client.meta.client.download_file(
+            "training-logs", "windows.tar.gz", "windows.tar.gz"
+        )
+        logging.info("Downloaded logs from minio successfully")
+
+        shutil.unpack_archive("windows.tar.gz", format="gztar")
+    except EndpointConnectionError:
+        logging.error(
+            f"Could not connect to minio with endpoint_url={MINIO_ENDPOINT} aws_access_key_id={MINIO_ACCESS_KEY} aws_secret_access_key={MINIO_SECRET_KEY} "
+        )
+        logging.info("Job failed")
+        return False
+
+    try:
+        minio_client.meta.client.head_bucket(Bucket="nulog-models")
+        logging.info("nulog-models bucket exists")
+    except botocore.exceptions.ClientError as e:
+        # If a client error is thrown, then check that it was a 404 error.
+        # If it was a 404 error, then the bucket does not exist.
+        error_code = e.response["Error"]["Code"]
+        if error_code == "404":
+            logging.info("nulog-models bucket does not exist so creating it now")
+            minio_client.create_bucket(Bucket="nulog-models")
+    return True
+
+
+async def send_signal_to_nats(nw):
+    await nw.publish(
+        "gpu_trainingjob_status", b"JobEnd"
+    )  ## tells the GPU service that a training job done.
+
+    nulog_payload = {
+        "bucket": "nulog-models",
+        "bucket_files": {
+            "model_file": "nulog_model_latest.pt",
+            "vocab_file": "vocab.txt",
+        },
+    }
+    await nw.publish(
+        nats_subject="model_ready", payload_df=json.dumps(nulog_payload).encode()
+    )
+    logging.info(
+        "Published to model_ready Nats subject that new Nulog model is ready to be used for inferencing."
+    )
+
+
+async def consume_signal(job_queue, nw):
+    await nw.subscribe(
+        nats_subject="gpu_service_training_internal", payload_queue=job_queue
+    )
+
+
+async def train_model(job_queue, nw):
+    minio_client = boto3.resource(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=MINIO_ACCESS_KEY,
+        aws_secret_access_key=MINIO_SECRET_KEY,
+        config=Config(signature_version="s3v4"),
+    )
+    windows_folder_path = "windows/"
+    while True:
+        new_job = await job_queue.get()  ## TODO: should the metadata being used?
+
+        res_download_data = minio_setup_and_download_data(minio_client)
+        res_train_model = train_nulog_model(minio_client, windows_folder_path)
+        if res_train_model:
+            await send_signal_to_nats(nw)
+        ## TODO: what to do if model training ever failed?
+
+
+async def init_nats(nw):
+    logging.info("Attempting to connect to NATS")
+    await nw.connect()
+
+
+def main():
+    loop = asyncio.get_event_loop()
+    job_queue = asyncio.Queue(loop=loop)
+    nw = NatsWrapper()
+
+    consumer_coroutine = consume_signal(job_queue, nw)
+    training_coroutine = train_model(job_queue, nw)
+
+    task = loop.create_task(init_nats(nw))
+    loop.run_until_complete(task)
+
+    loop.run_until_complete(asyncio.gather(training_coroutine, consumer_coroutine))
+    try:
+        loop.run_forever()
+    finally:
+        loop.close()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logging.info(f"Nulog training failed. Exception {e}")

--- a/nulog-inference-service/requirements.txt
+++ b/nulog-inference-service/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.17.45
 botocore==1.20.45
 elasticsearch==7.12.0
 numpy==1.17.4
-opni-nats==0.0.0.1
+opni-nats==0.0.0.2
 pandas==0.25.3
 scikit_learn==0.24.1
 torch==1.6.0

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -10,6 +10,7 @@ import time
 import pandas as pd
 from elasticsearch import AsyncElasticsearch
 from elasticsearch.helpers import async_bulk
+from nats.aio.errors import ErrTimeout
 from NulogServer import NulogServer
 from opni_nats import NatsWrapper
 
@@ -21,6 +22,23 @@ ES_ENDPOINT = os.environ["ES_ENDPOINT"]
 IS_CONTROL_PLANE_SERVICE = bool(os.getenv("IS_CONTROL_PLANE_SERVICE", False))
 
 nw = NatsWrapper()
+es = AsyncElasticsearch(
+    [ES_ENDPOINT],
+    port=9200,
+    http_compress=True,
+    http_auth=("admin", "admin"),
+    verify_certs=False,
+    use_ssl=True,
+)
+
+if IS_CONTROL_PLANE_SERVICE:
+    script_source = 'ctx._source.anomaly_level = ctx._source.anomaly_predicted_count == 0 ? "Normal" : "Anomaly";'
+else:
+    script_source = 'ctx._source.anomaly_level = ctx._source.anomaly_predicted_count == 0 ? "Normal" : ctx._source.anomaly_predicted_count == 1 ? "Suspicious" : "Anomaly";'
+script_source += "ctx._source.nulog_confidence = params['nulog_score'];"
+script_for_anomaly = (
+    "ctx._source.anomaly_predicted_count += 1; ctx._source.nulog_anomaly = true;"
+)
 
 
 async def consume_logs(logs_queue):
@@ -34,23 +52,53 @@ async def consume_logs(logs_queue):
             nats_queue="workers",
         )
     else:
-        await nw.subscribe(nats_subject="preprocessed_logs", payload_queue=logs_queue)
         await nw.subscribe(nats_subject="model_ready", payload_queue=logs_queue)
+        if IS_GPU_SERVICE:
+            await nw.subscribe(
+                nats_subject="gpu_service_inference_internal", payload_queue=logs_queue
+            )
+        else:
+            await nw.subscribe(
+                nats_subject="preprocessed_logs", payload_queue=logs_queue
+            )
+
+
+async def update_preds_to_es(df):
+    # df["nulog_confidence"] = predictions
+    df["predictions"] = [1 if p < THRESHOLD else 0 for p in df["nulog_confidence"]]
+    # filter out df to only include abnormal predictions
+
+    df["_op_type"] = "update"
+    df["_index"] = "logs"
+    df.rename(columns={"log_id": "_id"}, inplace=True)
+    df["script"] = [
+        {
+            "source": (script_for_anomaly + script_source)
+            if nulog_score < THRESHOLD
+            else script_source,
+            "lang": "painless",
+            "params": {"nulog_score": nulog_score},
+        }
+        for nulog_score in df["nulog_confidence"]
+    ]
+    try:
+        await async_bulk(es, doc_generator(df[["_id", "_op_type", "_index", "script"]]))
+        logging.info(
+            "Updated {} anomalies from {} logs to ES in {} seconds".format(
+                len(df[df["predictions"] > 0]),
+                len(masked_log),
+                time.time() - start_time,
+            )
+        )
+    except Exception as e:
+        logging.error(e)
 
 
 async def infer_logs(logs_queue):
     """
     coroutine to get payload from logs_queue, call inference rest API and put predictions to elasticsearch.
     """
-    es = AsyncElasticsearch(
-        [ES_ENDPOINT],
-        port=9200,
-        http_compress=True,
-        http_auth=("admin", "admin"),
-        verify_certs=False,
-        use_ssl=True,
-    )
-
+    saved_preds = defaultdict(float)
     nulog_predictor = NulogServer()
     if IS_CONTROL_PLANE_SERVICE:
         nulog_predictor.load(save_path="control-plane-output/")
@@ -62,15 +110,6 @@ async def infer_logs(logs_queue):
         for index, document in df.iterrows():
             doc_dict = document.to_dict()
             yield doc_dict
-
-    if IS_CONTROL_PLANE_SERVICE:
-        script_source = 'ctx._source.anomaly_level = ctx._source.anomaly_predicted_count == 0 ? "Normal" : "Anomaly";'
-    else:
-        script_source = 'ctx._source.anomaly_level = ctx._source.anomaly_predicted_count == 0 ? "Normal" : ctx._source.anomaly_predicted_count == 1 ? "Suspicious" : "Anomaly";'
-    script_source += "ctx._source.nulog_confidence = params['nulog_score'];"
-    script_for_anomaly = (
-        "ctx._source.anomaly_predicted_count += 1; ctx._source.nulog_anomaly = true;"
-    )
 
     max_payload_size = 128 if IS_CONTROL_PLANE_SERVICE else 512
     while True:
@@ -89,44 +128,49 @@ async def infer_logs(logs_queue):
             continue
 
         df_payload = pd.read_json(payload, dtype={"_id": object})
+        if "nulog_confidence" in df_payload.columns:
+            for score, log in zip(
+                df_payload["nulog_confidence"], df_payload["masked_log"]
+            ):
+                saved_preds[log] = score
+            continue
+
         for i in range(0, len(df_payload), max_payload_size):
             df = df_payload[i : min(i + max_payload_size, len(df_payload))]
-            masked_log = list(df["masked_log"])
-            predictions = nulog_predictor.predict(masked_log)
-            if predictions is None:
-                logging.warning("fail to make predictions.")
-                continue
 
-            df["nulog_confidence"] = predictions
-            df["predictions"] = [1 if p < THRESHOLD else 0 for p in predictions]
-            # filter out df to only include abnormal predictions
-
-            df["_op_type"] = "update"
-            df["_index"] = "logs"
-            df.rename(columns={"log_id": "_id"}, inplace=True)
-            df["script"] = [
-                {
-                    "source": (script_for_anomaly + script_source)
-                    if nulog_score < THRESHOLD
-                    else script_source,
-                    "lang": "painless",
-                    "params": {"nulog_score": nulog_score},
-                }
-                for nulog_score in df["nulog_confidence"]
+            is_log_cached = df["masked_log"] in saved_preds
+            df_cached_logs = df[is_log_cached]
+            df_new_logs = df[~is_log_cached]
+            df_cached_logs["nulog_confidence"] = saved_preds[
+                df_cached_logs["masked_log"]
             ]
-            try:
-                await async_bulk(
-                    es, doc_generator(df[["_id", "_op_type", "_index", "script"]])
-                )
-                logging.info(
-                    "Updated {} anomalies from {} logs to ES in {} seconds".format(
-                        len(df[df["predictions"] > 0]),
-                        len(masked_log),
-                        time.time() - start_time,
+            await update_preds_to_es(df_cached_logs)
+
+            if not (IS_GPU_SERVICE or IS_CONTROL_PLANE_SERVICE):
+                try:  # try to post request to GPU service
+                    response = await nw.nc.request(
+                        "gpu_service_inference", pd.to_json(df_new_logs), timeout=1
                     )
-                )
-            except Exception as e:
-                logging.error(e)
+                except ErrTimeout:
+                    logging.warning("request to GPU service timeout.")
+                    response = "request declined."
+
+            if not response or IS_GPU_SERVICE or IS_CONTROL_PLANE_SERVICE:
+                masked_logs = list(df_new_logs["masked_log"])
+                pred_scores = nulog_predictor.predict(masked_logs)
+
+                if pred_scores is None:
+                    logging.warning("fail to make predictions.")
+                else:
+                    df_new_logs["nulog_confidence"] = pred_scores
+                    for p, m in zip(pred_scores, masked_logs):
+                        saved_preds[m] = p
+                    if IS_GPU_SERVICE:
+                        nw.publish(
+                            nats_subject="gpu_inference_results",
+                            payload=pd.to_json(df_new_logs),
+                        )
+                    await update_preds_to_es(df_new_logs)
 
             del df
             del masked_log


### PR DESCRIPTION
what does this PR do:
1. merge nulog-train to this repo, so that the gpu-service can have a coroutine for nulog-train and a coroutine for nulog-inference.
2. the nulog-cpu-service can post inferencing request to the gpu-service.
3. the same image can be used by 3 different services: nulog-cp-service, nulog-cpu-service, nulog-gpu-service.

Dependency:
- [x] rancher/opni-nats-wrapper#2 needs to be merged and have opni-nats==0.0.0.2 released before testing this PR. build is failing because opni-nats==0.0.0.2 doesn't exist yet.