### PR TITLE
Make updates to NuLog code so it will recreate windows directory every time it needs to be trained and also update Nats connecticity

### DIFF
--- a/models/nulog/NuLogParser.py
+++ b/models/nulog/NuLogParser.py
@@ -124,10 +124,11 @@ class LogParser:
             betas=self.betas,
             weight_decay=self.weight_decay,
         )
-
+        '''
         if (self.model_name) in os.listdir(self.savePath):
             # model.load_state_dict(torch.load(self.model_path))
             prev_epoch, prev_loss = self.load_model(model, model_opt)
+        '''
 
         train_dataloader = self.get_train_dataloaders(
             data_tokenized, transform_to_tensor

--- a/nulog-inference-service/NulogTrain.py
+++ b/nulog-inference-service/NulogTrain.py
@@ -41,6 +41,7 @@ def train_nulog_model(minio_client, windows_folder_path):
             "output/vocab.txt", "nulog-models", "vocab.txt"
         )
         logger.info("Nulog model and vocab have been uploaded to Minio.")
+        shutil.rmtree('windows/')
     else:
         logger.error("Nulog model was not able to be trained and saved successfully.")
         return False
@@ -75,6 +76,7 @@ def minio_setup_and_download_data(minio_client):
 
 
 async def send_signal_to_nats(nw):
+    await nw.connect()
     await nw.publish(
         "gpu_trainingjob_status", b"JobEnd"
     )  ## tells the GPU service that a training job done.

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -132,6 +132,7 @@ async def infer_logs(logs_queue):
         decoded_payload = json.loads(payload)
         if "bucket" in decoded_payload and decoded_payload["bucket"] == "nulog-models":
             # signal to reload model
+            logger.info("Received signal to load Nulog model.")
             if IS_CONTROL_PLANE_SERVICE:
                 nulog_predictor.load(save_path="control-plane-output/")
             else:


### PR DESCRIPTION
This PR addresses a couple of things.

1. After a couple of times where a Nulog model is being trained, the signal "JobEnd" which is sent to the Nats subject "gpu_trainingjob_status" was no longer being received and observing the logs, it seemed as if during that span connectivity to Nats was lost and a reconnection was being made. Hence, this PR connects to the Nats wrapper every time a new Nulog model is being trained and then sends the signals. 

2. After a new Nulog model is trained, the windows directory which consisted of all the logs to be used for training needs to be deleted. Otherwise, in the event that logs that are to be used for training are deleted from Elasticsearch and thus no longer available to be fetched by Elasticdump, they will still persist and be used in training of future models which is not a desired outcome so logic was added to address this as well.