### PR TITLE
Switch to use file configuration for hyper parameters

### DIFF
--- a/nulog-inference-service/HyperParamaters.py
+++ b/nulog-inference-service/HyperParamaters.py
@@ -4,17 +4,17 @@ class HyperParameters:
     def __init__(self):
         self._MODEL_THRESHOLD = float(0.7)
         self._MIN_LOG_TOKENS = int(1)
+        self._IS_CONTROL_PLANE = False
         f = open('/etc/opni/hyperparameters.json', 'r')
         data = json.load(f)
         if data is None:
             return
-        if "hyperparameters" not in data:
-            return
-        hyperparameters = data["hyperparameters"]
-        if "modelThreshold" in hyperparameters["modelThreshold"]:
+        if "modelThreshold" in data:
             self._MODEL_THRESHOLD = float(data["modelThreshold"])
-        if "minLogTokens" in hyperparameters["minLogTokens"]:
-            self._MODEL_THRESHOLD = float(data["minLogTokens"])
+        if "minLogTokens" in data:
+            self._MIN_LOG_TOKENS = int(data["minLogTokens"])
+        if "isControlPlane" in data:
+            self._IS_CONTROL_PLANE = data["isControlPlane"].lower() == "true"
         f.close()
 
 
@@ -25,3 +25,7 @@ class HyperParameters:
     @property
     def MIN_LOG_TOKENS(self):
         return self._MIN_LOG_TOKENS
+
+    @property
+    def IS_CONTROL_PLANE(self):
+        return self._IS_CONTROL_PLANE

--- a/nulog-inference-service/HyperParamaters.py
+++ b/nulog-inference-service/HyperParamaters.py
@@ -6,6 +6,8 @@ class HyperParameters:
         self._MIN_LOG_TOKENS = int(1)
         f = open('/etc/opni/hyperparameters.json', 'r')
         data = json.load(f)
+        if data is None:
+            return
         if "hyperparameters" not in data:
             return
         hyperparameters = data["hyperparameters"]

--- a/nulog-inference-service/HyperParamaters.py
+++ b/nulog-inference-service/HyperParamaters.py
@@ -1,0 +1,25 @@
+import json
+
+class HyperParameters:
+    def __init__(self):
+        self._MODEL_THRESHOLD = float(0.7)
+        self._MIN_LOG_TOKENS = int(1)
+        f = open('/etc/opni/hyperparameters.json', 'r')
+        data = json.load(f)
+        if "hyperparameters" not in data:
+            return
+        hyperparameters = data["hyperparameters"]
+        if "modelThreshold" in hyperparameters["modelThreshold"]:
+            self._MODEL_THRESHOLD = float(data["modelThreshold"])
+        if "minLogTokens" in hyperparameters["minLogTokens"]:
+            self._MODEL_THRESHOLD = float(data["minLogTokens"])
+        f.close()
+
+
+    @property
+    def MODEL_THRESHOLD(self):
+        return self._MODEL_THRESHOLD
+
+    @property
+    def MIN_LOG_TOKENS(self):
+        return self._MIN_LOG_TOKENS

--- a/nulog-inference-service/HyperParamaters.py
+++ b/nulog-inference-service/HyperParamaters.py
@@ -6,7 +6,7 @@ class HyperParameters:
         self._MODEL_THRESHOLD = float(0.7)
         self._MIN_LOG_TOKENS = int(1)
         self._IS_CONTROL_PLANE = False
-        if not(os.path.ifile('/etc/opni/hyperparameters.json')):
+        if not(os.path.exists('/etc/opni/hyperparameters.json')):
             return
         f = open('/etc/opni/hyperparameters.json', 'r')
         data = json.load(f)

--- a/nulog-inference-service/HyperParamaters.py
+++ b/nulog-inference-service/HyperParamaters.py
@@ -1,10 +1,13 @@
 import json
+import os
 
 class HyperParameters:
     def __init__(self):
         self._MODEL_THRESHOLD = float(0.7)
         self._MIN_LOG_TOKENS = int(1)
         self._IS_CONTROL_PLANE = False
+        if not(os.path.ifile('/etc/opni/hyperparameters.json')):
+            return
         f = open('/etc/opni/hyperparameters.json', 'r')
         data = json.load(f)
         if data is None:

--- a/nulog-inference-service/NulogServer.py
+++ b/nulog-inference-service/NulogServer.py
@@ -25,13 +25,13 @@ DEFAULT_MODELREADY_PAYLOAD = {
         "vocab_file": "vocab.txt",
     },
 }
-MIN_LOG_TOKENS = int(os.getenv("MIN_LOG_TOKENS", 1))
 
 
 class NulogServer:
-    def __init__(self):
+    def __init__(self, min_log_tokens):
         self.is_ready = False
         self.parser = None
+        self.MIN_LOG_TOKENS = min_log_tokens
 
     def download_from_s3(
         self,
@@ -72,7 +72,7 @@ class NulogServer:
         except Exception as e:
             logger.error(f"No Nulog model currently {e}")
 
-    def predict(self, min_log_tokens, logs: List[str]):
+    def predict(self, logs: List[str]):
         """
         logs: masked logs
         """
@@ -84,7 +84,7 @@ class NulogServer:
         output = []
         for log in logs:
             tokens = self.parser.tokenize_data([log], isTrain=False)
-            if len(tokens[0]) < min_log_tokens:
+            if len(tokens[0]) < self.MIN_LOG_TOKENS:
                 output.append(1)
             else:
                 pred = (self.parser.predict(tokens))[0]

--- a/nulog-inference-service/NulogServer.py
+++ b/nulog-inference-service/NulogServer.py
@@ -72,7 +72,7 @@ class NulogServer:
         except Exception as e:
             logger.error(f"No Nulog model currently {e}")
 
-    def predict(self, logs: List[str]):
+    def predict(self, min_log_tokens, logs: List[str]):
         """
         logs: masked logs
         """
@@ -84,7 +84,7 @@ class NulogServer:
         output = []
         for log in logs:
             tokens = self.parser.tokenize_data([log], isTrain=False)
-            if len(tokens[0]) < MIN_LOG_TOKENS:
+            if len(tokens[0]) < min_log_tokens:
                 output.append(1)
             else:
                 pred = (self.parser.predict(tokens))[0]

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -30,7 +30,11 @@ logger.setLevel(LOGGING_LEVEL)
 
 params = HyperParameters()
 THRESHOLD = params.MODEL_THRESHOLD
+if "MODEL_THRESHOLD" in os.environ:
+    THRESHOLD = os.environ["MODEL_THRESHOLD"]
 MIN_LOG_TOKENS = params.MIN_LOG_TOKENS
+if "MIN_LOG_TOKENS" in os.environ:
+    MIN_LOG_TOKENS = os.environ["MIN_LOG_TOKENS"]
 ES_ENDPOINT = os.environ["ES_ENDPOINT"]
 ES_USERNAME = os.getenv("ES_USERNAME", "admin")
 ES_PASSWORD = os.getenv("ES_PASSWORD", "admin")

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -19,7 +19,7 @@ from elasticsearch import AsyncElasticsearch
 from elasticsearch.helpers import async_bulk
 from HyperParamaters import HyperParameters
 from nats.aio.errors import ErrTimeout
-from NulogServer import MIN_LOG_TOKENS, NulogServer
+from NulogServer import NulogServer
 from NulogTrain import consume_signal, train_model
 from opni_nats import NatsWrapper
 
@@ -31,10 +31,10 @@ logger.setLevel(LOGGING_LEVEL)
 params = HyperParameters()
 THRESHOLD = params.MODEL_THRESHOLD
 if "MODEL_THRESHOLD" in os.environ:
-    THRESHOLD = os.environ["MODEL_THRESHOLD"]
+    THRESHOLD = float(os.environ["MODEL_THRESHOLD"])
 MIN_LOG_TOKENS = params.MIN_LOG_TOKENS
 if "MIN_LOG_TOKENS" in os.environ:
-    MIN_LOG_TOKENS = os.environ["MIN_LOG_TOKENS"]
+    MIN_LOG_TOKENS = int(os.environ["MIN_LOG_TOKENS"])
 ES_ENDPOINT = os.environ["ES_ENDPOINT"]
 ES_USERNAME = os.getenv("ES_USERNAME", "admin")
 ES_PASSWORD = os.getenv("ES_PASSWORD", "admin")
@@ -283,7 +283,7 @@ async def infer_logs(logs_queue):
                         logger.debug(
                             f" {len(unique_masked_logs)} unique logs to inference."
                         )
-                        pred_scores_dict = nulog_predictor.predict(MIN_LOG_TOKENS, unique_masked_logs)
+                        pred_scores_dict = nulog_predictor.predict(unique_masked_logs)
 
                         if pred_scores_dict is None:
                             logger.warning("fail to make predictions.")

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -215,7 +215,7 @@ async def infer_logs(logs_queue):
     s3_setup(s3_client)
     saved_preds = defaultdict(float)
     load_cached_preds(saved_preds)
-    nulog_predictor = NulogServer()
+    nulog_predictor = NulogServer(MIN_LOG_TOKENS)
     if IS_CONTROL_PLANE_SERVICE:
         nulog_predictor.load(save_path="control-plane-output/")
     else:

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -35,6 +35,9 @@ if "MODEL_THRESHOLD" in os.environ:
 MIN_LOG_TOKENS = params.MIN_LOG_TOKENS
 if "MIN_LOG_TOKENS" in os.environ:
     MIN_LOG_TOKENS = int(os.environ["MIN_LOG_TOKENS"])
+IS_CONTROL_PLANE_SERVICE = params.IS_CONTROL_PLANE
+if "IS_CONTROL_PLANE" in os.environ:
+    IS_CONTROL_PLANE_SERVICE = bool(os.environ["IS_CONTROL_PLANE_SERVICE"])
 ES_ENDPOINT = os.environ["ES_ENDPOINT"]
 ES_USERNAME = os.getenv("ES_USERNAME", "admin")
 ES_PASSWORD = os.getenv("ES_PASSWORD", "admin")
@@ -42,7 +45,6 @@ S3_ENDPOINT = os.environ["S3_ENDPOINT"]
 S3_ACCESS_KEY = os.environ["S3_ACCESS_KEY"]
 S3_SECRET_KEY = os.environ["S3_SECRET_KEY"]
 S3_BUCKET = os.getenv("S3_BUCKET", "opni-nulog-models")
-IS_CONTROL_PLANE_SERVICE = bool(os.getenv("IS_CONTROL_PLANE_SERVICE", False))
 IS_GPU_SERVICE = bool(os.getenv("IS_GPU_SERVICE", False))
 CACHED_PREDS_SAVEFILE = (
     "control-plane-preds.txt"
@@ -52,6 +54,10 @@ CACHED_PREDS_SAVEFILE = (
     else "cpu-preds.txt"
 )
 SAVE_FREQ = 25
+
+logger.debug(f"model threshold is {THRESHOLD}")
+logger.debug(f"min log tokens is is {MIN_LOG_TOKENS}")
+logger.debug(f"is controlplane is  {IS_CONTROL_PLANE_SERVICE}")
 
 nw = NatsWrapper()
 es = AsyncElasticsearch(


### PR DESCRIPTION
This PR switches the inference service to use hyperparameters that are defined in a json file, rather than in environment variables.