### PR TITLE
Change Nats subject name for receiving control plane logs from DRAIN Control Plane Service

### DIFF
--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -92,7 +92,7 @@ async def consume_logs(logs_queue):
     """
     if IS_CONTROL_PLANE_SERVICE:
         await nw.subscribe(
-            nats_subject="preprocessed_logs_control_plane",
+            nats_subject="nulog_cp_logs",
             payload_queue=logs_queue,
             nats_queue="workers",
         )


### PR DESCRIPTION
This PR simply changes the name of the Nats subject from which the Nulog control plane inferencing service will be subscribing to for control plane logs. Previously, this service was subscribed to the Nats subject: preprocessed_logs_control_plane but now it will be subscribed to the nulog_cp_logs Nats subject. 