### PR TITLE
Update Nulog control plane inferencing service for v0.4.

### DIFF
--- a/models/nulog/masker.py
+++ b/models/nulog/masker.py
@@ -28,12 +28,27 @@ class RegexMasker:
         self.remove_delimiters = r'([| \(|\)|\[|\]\'|\{|\}|"|,])'
         self.ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]")
 
-    def mask(self, content: str):
+    def mask(self, content: str, is_control_plane_log: bool):
 
         # get rid of escape keys
         content = self.ansi_escape.sub("", content)
 
-        # reduce any json objects (TODO)
+        # If log is a control plane log, mask out content from structured control plane log messages which follow the 'a="somecontent" to be a=<a>'
+        if is_control_plane_log:
+            assignment_regex = '([A-z]+)="(.*?)"'
+            matching_indices = [
+                (m.start(0), m.end(0)) for m in re.finditer(assignment_regex, content)
+            ]
+            modified_content = content[:]
+
+            for m in matching_indices:
+                substring = content[m[0] : m[1]]
+                left_side_term = substring.split('="')[0]
+                if left_side_term != "err":
+                    modified_content = modified_content.replace(
+                        substring, f"{left_side_term}=<{left_side_term}>"
+                    )
+            content = modified_content[:]
 
         for mi in self.masking_instructions_before_value_assign_token_split:
             # content = re.sub(mi.regex, mi.mask_with_wrapped, content)
@@ -59,6 +74,7 @@ class RegexMasker:
 
 
 masking_list = [
+    {"regex_pattern": "[^\\s]+.go : [0-9]+", "mask_with": "GO_FILE_PATH"},
     {
         "regex_pattern": "[a-z0-9]+[\\._]?[a-z0-9]+[@]\\w+[.]\\w{2,3}",
         "mask_with": "EMAIL_ADDRESS",
@@ -128,5 +144,5 @@ class LogMasker:
             masking_instructions_before_value_assigning_token_split,
         )
 
-    def mask(self, content: str):
-        return self.masker.mask(content)
+    def mask(self, content: str, is_control_plane_log: bool):
+        return self.masker.mask(content, is_control_plane_log)

--- a/nulog-inference-service/start-nulog-inference.py
+++ b/nulog-inference-service/start-nulog-inference.py
@@ -92,7 +92,7 @@ async def consume_logs(logs_queue):
     """
     if IS_CONTROL_PLANE_SERVICE:
         await nw.subscribe(
-            nats_subject="preprocessed_logs_control_plane",
+            nats_subject="nulog_cp_logs",
             payload_queue=logs_queue,
             nats_queue="workers",
         )


### PR DESCRIPTION
This PR changes the name of the Nats subject from which the Nulog control plane inferencing service will be subscribing to for control plane logs. Previously, this service was subscribed to the Nats subject: preprocessed_logs_control_plane but now it will be subscribed to the nulog_cp_logs Nats subject. It also no longer will be using the script logic that was being used to update the logs back into Opensearch for the control plane service. 