### PR TITLE
Update Opnilog inferencing service to send inferred logs to Opensearch updating service

### DIFF
--- a/opnilog-inference-service/start_opnilog_inference.py
+++ b/opnilog-inference-service/start_opnilog_inference.py
@@ -83,8 +83,6 @@ async def infer_logs(logs_queue):
         payload = await logs_queue.get()
         if payload is None:
             continue
-        logging.info("received payload")
-        logging.info(payload)
         decoded_payload = json.loads(payload)
         if len(decoded_payload) == 1:
             pending_list.append(decoded_payload[0])


### PR DESCRIPTION
This PR adds logic to the inferencing service so once the logs have been inferred on, it will write to the inferenced_logs Nats subject instead of updating to Opensearch itself.