### PR TITLE
Add logic for exception handling for fetching of logs

### DIFF
--- a/opni_inference_service/opnilog_trainer.py
+++ b/opni_inference_service/opnilog_trainer.py
@@ -38,6 +38,8 @@ es_instance = AsyncElasticsearch(
     use_ssl=True,
 )
 
+RETRY_LIMIT = 5
+
 
 async def get_all_training_data(payload):
     """

--- a/opni_inference_service/opnilog_trainer.py
+++ b/opni_inference_service/opnilog_trainer.py
@@ -17,7 +17,7 @@ from const import (
     TRAINING_DATA_PATH,
 )
 from elasticsearch import AsyncElasticsearch
-from elasticsearch.exceptions import *
+from elasticsearch.exceptions import NotFoundError
 from opni_nats import NatsWrapper
 from utils import get_s3_client, s3_setup
 
@@ -42,13 +42,6 @@ es_instance = AsyncElasticsearch(
 )
 
 RETRY_LIMIT = 5
-
-
-def mask_logs(all_training_logs):
-    all_masked_logs = []
-    for log in all_training_logs:
-        all_masked_logs.append(masker.mask(log))
-    return all_masked_logs
 
 
 async def get_all_training_data(payload):
@@ -98,7 +91,7 @@ async def train_opnilog_model(nw, s3_client, query):
     # Load the training data.
     try:
         texts = await get_all_training_data(query)
-        masked_logs = mask_logs(texts)
+        masked_logs = [masker.mask(log) for log in texts]
     except Exception as e:
         logging.error(f"Unable to load data. {e}")
         return False

--- a/opni_inference_service/opnilog_trainer.py
+++ b/opni_inference_service/opnilog_trainer.py
@@ -41,6 +41,13 @@ es_instance = AsyncElasticsearch(
 RETRY_LIMIT = 5
 
 
+def mask_logs(all_training_logs):
+    all_masked_logs = []
+    for log in all_training_logs:
+        all_masked_logs.append(masker.mask(log))
+    return all_masked_logs
+
+
 async def get_all_training_data(payload):
     """
     get training data from Opensearch and mask them.
@@ -94,9 +101,9 @@ async def train_opnilog_model(nw, s3_client, query):
         MAX_TRAINING_SAMPLE_SIZE if len(texts) > MAX_TRAINING_SAMPLE_SIZE else 0
     )
     # Check to see if the length of the training data is at least 1. Otherwise, return False.
-    if len(texts) > 0:
+    if len(masked_logs) > 0:
         try:
-            tokenized = parser.tokenize_data(texts, isTrain=True)
+            tokenized = parser.tokenize_data(masked_logs, isTrain=True)
             parser.tokenizer.save_vocab()
             parser.train(
                 tokenized,

--- a/opni_inference_service/opnilog_trainer.py
+++ b/opni_inference_service/opnilog_trainer.py
@@ -17,10 +17,12 @@ from const import (
     TRAINING_DATA_PATH,
 )
 from elasticsearch import AsyncElasticsearch
-from models.opnilog.masker import LogMasker
-from models.opnilog.opnilog_parser import LogParser
 from opni_nats import NatsWrapper
 from utils import get_s3_client, s3_setup
+
+# Local
+from models.opnilog.masker import LogMasker
+from models.opnilog.opnilog_parser import LogParser
 
 logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__file__)
@@ -85,6 +87,7 @@ async def train_opnilog_model(nw, s3_client, query):
     # Load the training data.
     try:
         texts = await get_all_training_data(query)
+        masked_logs = mask_logs(texts)
     except Exception as e:
         logging.error(f"Unable to load data. {e}")
         return False


### PR DESCRIPTION
This PR adds exception handling when it comes to fetching logs from Opensearch. It will retry up to 5 times to fetch logs from Opensearch from the point of the scroll_id before it exits the function and returns the logs that were fetched beforehand.

Addresses issue: https://github.com/rancher/opni/issues/1092